### PR TITLE
[HOTFIX] Remove skip session storage that unnecessary

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -97,7 +97,7 @@ Devise.setup do |config|
   # Notice that if you are skipping storage for all authentication paths, you
   # may want to disable generating routes to Devise's sessions controller by
   # passing skip: :sessions to `devise_for` in your config/routes.rb
-  config.skip_session_storage = %i[http_auth params_auth]
+  config.skip_session_storage = %i[http_auth]
 
   # By default, Devise cleans up the CSRF token on authentication to
   # avoid CSRF token fixation attacks. This means that, when using AJAX
@@ -313,7 +313,7 @@ Devise.setup do |config|
   config.jwt do |jwt|
     jwt.secret = ENV['JWT_SECRET_KEY']
     jwt.dispatch_requests = [
-      ['POST', %r{/sign_in}]
+      ['POST', %r{/api/v1/users/sign_in}]
     ]
     jwt.revocation_requests = [
       ['DELETE', %r{/sign_out}]


### PR DESCRIPTION
- That cause the user cannot access the page that required authentication after login.