### PR TITLE
[HOTFIX] Worker cannot save Nokogiri::XML

### DIFF
--- a/app/services/crawl_google_data_service.rb
+++ b/app/services/crawl_google_data_service.rb
@@ -51,10 +51,14 @@ class CrawlGoogleDataService
 
   def parse_ads
     data.css("#{ADS_ID} > div").map(&:value)
+  rescue StandardError
+    data.css("#{ADS_ID} > div").map(&:content)
   end
 
   def parse_links
     data.css('a > @href').uniq.map(&:value)
+  rescue StandardError
+    data.css('a > @href').uniq
   end
 
   def parse_totol_result


### PR DESCRIPTION
- Raise error worker when `parse ads` with type Nokogiri::XML::NodeSet:Class
- Try to get either content or value attribute of ads