### PR TITLE
[#44][Backend] Add unit tests for results controller

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -8,10 +8,4 @@ class ResultsController < ApplicationController
   def show
     @result = current_user.results.find_by(id: params[:id])
   end
-
-  private
-
-  def attachment_params
-    params.require(:attachment).permit(:file)
-  end
 end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -6,6 +6,6 @@ class ResultsController < ApplicationController
   end
 
   def show
-    @result = current_user.results.find_by(id: params[:id])
+    @result = current_user.results.find(params[:id])
   end
 end

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ResultsController, type: :controller do
         another_user = create :user
         number_of_results = 10
         attachment = create :attachment, user_id: user.id
-        un_authored_attachment = create :attachment, user_id: another_user.id
+        another_user_attachment = create :attachment, user_id: another_user.id
         create_list :result, number_of_results, attachment_id: attachment.id
 
         sign_in user
@@ -31,7 +31,7 @@ RSpec.describe ResultsController, type: :controller do
         expect(response).to have_http_status :success
         expect(results.size).to eq(number_of_results)
         expect(results.klass.name).to eq(Result.name)
-        expect(results.pluck('DISTINCT attachment_id')).not_to include(un_authored_attachment.id)
+        expect(results.pluck('DISTINCT attachment_id')).not_to include(another_user_attachment.id)
       end
     end
 

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -100,12 +100,12 @@ RSpec.describe ResultsController, type: :controller do
       it 'raises a record not found error' do
         user = create :user
         another_user = create :user
-        un_authored_attachment = create :attachment, user_id: another_user.id
-        un_authored_result = create :result, attachment_id: un_authored_attachment.id
+        another_user_attachment = create :attachment, user_id: another_user.id
+        another_user_result = create :result, attachment_id: another_user_attachment.id
 
         sign_in user
         expect do
-          get :show, params: { id: un_authored_result.id }
+          get :show, params: { id: another_user_result.id }
         end.to raise_error(ActiveRecord::RecordNotFound)
       end
     end

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe ResultsController, type: :controller do
+  let(:user) { create :user }
+  let(:other_user) { create :user }
+  before { sign_in user }
+
+  describe 'Filters' do
+    it { should use_before_action(:authenticate_user!) }
+  end
+
+  describe 'GET #index' do
+    subject { get :index }
+
+    let(:number_of_results) { 10 }
+    let(:attachment) { create :attachment, user_id: user.id }
+    let(:un_authored_attachment) { create :attachment, user_id: other_user.id }
+
+    context 'without params' do
+      before { create_list :result, number_of_results, attachment_id: attachment.id }
+
+      it 'returns all results of user' do
+        expect(subject).to have_http_status :success
+        expect(controller.instance_variable_get(:@results).size).to eq(number_of_results)
+        expect(controller.instance_variable_get(:@results).klass.name).to eq(Result.name)
+        expect(controller.instance_variable_get(:@results).pluck('DISTINCT attachment_id')).not_to include(un_authored_attachment.id)
+      end
+    end
+
+    context 'filtered by keyword' do
+      subject { get :index, params: { q: keyword } }
+
+      let(:keyword) { 'e' }
+      let!(:nimble_result) { create :result, keyword: 'Nimble', attachment_id: attachment.id }
+      let!(:company_result) { create :result, keyword: 'company', attachment_id: attachment.id }
+      let!(:vietnam_result) { create :result, keyword: 'VietNam', attachment_id: attachment.id }
+
+      it 'returns all filtered results of user' do
+        expect(subject).to have_http_status :success
+        expect(controller.instance_variable_get(:@results).size).to eq(2)
+        expect(controller.instance_variable_get(:@results).klass.name).to eq(Result.name)
+        expect(controller.instance_variable_get(:@results).pluck('DISTINCT keyword')).to include(nimble_result.keyword, vietnam_result.keyword)
+        expect(controller.instance_variable_get(:@results).pluck('DISTINCT keyword')).not_to include(company_result.keyword)
+        expect(controller.instance_variable_get(:@results).pluck('DISTINCT attachment_id')).not_to include(un_authored_attachment.id)
+      end
+    end
+  end
+
+  describe 'GET #show' do
+    subject { get :show, params: { id: result.id } }
+
+    let(:attachment) { create :attachment, user_id: user.id }
+    let(:result) { create :result, attachment_id: attachment.id }
+    let(:un_authored_attachment) { create :attachment, user_id: other_user.id }
+    let(:un_authored_result) { create :result, attachment_id: un_authored_attachment.id }
+
+    it 'returns result of user' do
+      params = { id: result.id }
+      get :show, params: params
+
+      expect(response).to have_http_status :success
+      expect(controller.instance_variable_get(:@result)).to be_a(Result)
+      expect(controller.instance_variable_get(:@result)).to eq(result)
+    end
+
+    it 'returns nil for un-authored result' do
+      params = { id: un_authored_result.id }
+      get :show, params: params
+
+      expect(response).to have_http_status :success
+      expect(controller.instance_variable_get(:@result)).to eq(nil)
+    end
+  end
+end

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe ResultsController, type: :controller do
-  let(:user) { create :user }
-  let(:other_user) { create :user }
-  before { sign_in user }
-
   describe 'Filters' do
     it { should use_before_action(:authenticate_user!) }
   end
@@ -12,11 +8,14 @@ RSpec.describe ResultsController, type: :controller do
   describe 'GET #index' do
     context 'without params' do
       it 'returns all results of user' do
+        user = create :user
+        other_user = create :user
         number_of_results = 10
         attachment = create :attachment, user_id: user.id
         un_authored_attachment = create :attachment, user_id: other_user.id
         create_list :result, number_of_results, attachment_id: attachment.id
 
+        sign_in user
         get :index
         results = controller.instance_variable_get(:@results)
 
@@ -29,6 +28,8 @@ RSpec.describe ResultsController, type: :controller do
 
     context 'when filtered by keyword' do
       it 'returns all filtered results of user' do
+        user = create :user
+        other_user = create :user
         keyword = 'e'
         attachment = create :attachment, user_id: user.id
         nimble_result = create :result, keyword: 'Nimble', attachment_id: attachment.id
@@ -36,6 +37,7 @@ RSpec.describe ResultsController, type: :controller do
         vietnam_result = create :result, keyword: 'VietNam', attachment_id: attachment.id
         un_authored_attachment = create :attachment, user_id: other_user.id
 
+        sign_in user
         get :index, params: { q: keyword }
         results = controller.instance_variable_get(:@results)
 
@@ -51,10 +53,12 @@ RSpec.describe ResultsController, type: :controller do
 
   describe 'GET #show' do
     it 'returns result of user' do
+      user = create :user
       attachment = create :attachment, user_id: user.id
       result = create :result, attachment_id: attachment.id
       params = { id: result.id }
 
+      sign_in user
       get :show, params: params
 
       expect(response).to have_http_status :success
@@ -63,10 +67,13 @@ RSpec.describe ResultsController, type: :controller do
     end
 
     it 'returns nil for un-authored result' do
+      user = create :user
+      other_user = create :user
       un_authored_attachment = create :attachment, user_id: other_user.id
       un_authored_result = create :result, attachment_id: un_authored_attachment.id
       params = { id: un_authored_result.id }
 
+      sign_in user
       get :show, params: params
 
       expect(response).to have_http_status :success

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -50,13 +50,6 @@ RSpec.describe ResultsController, type: :controller do
   end
 
   describe 'GET #show' do
-    subject { get :show, params: { id: result.id } }
-
-    let(:attachment) { create :attachment, user_id: user.id }
-    let(:result) { create :result, attachment_id: attachment.id }
-    let(:un_authored_attachment) { create :attachment, user_id: other_user.id }
-    let(:un_authored_result) { create :result, attachment_id: un_authored_attachment.id }
-
     it 'returns result of user' do
       attachment = create :attachment, user_id: user.id
       result = create :result, attachment_id: attachment.id

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -10,38 +10,41 @@ RSpec.describe ResultsController, type: :controller do
   end
 
   describe 'GET #index' do
-    subject { get :index }
-
-    let(:number_of_results) { 10 }
-    let(:attachment) { create :attachment, user_id: user.id }
-    let(:un_authored_attachment) { create :attachment, user_id: other_user.id }
-
     context 'without params' do
-      before { create_list :result, number_of_results, attachment_id: attachment.id }
-
       it 'returns all results of user' do
-        expect(subject).to have_http_status :success
-        expect(controller.instance_variable_get(:@results).size).to eq(number_of_results)
-        expect(controller.instance_variable_get(:@results).klass.name).to eq(Result.name)
-        expect(controller.instance_variable_get(:@results).pluck('DISTINCT attachment_id')).not_to include(un_authored_attachment.id)
+        number_of_results = 10
+        attachment = create :attachment, user_id: user.id
+        un_authored_attachment = create :attachment, user_id: other_user.id
+        create_list :result, number_of_results, attachment_id: attachment.id
+
+        get :index
+        results = controller.instance_variable_get(:@results)
+
+        expect(response).to have_http_status :success
+        expect(results.size).to eq(number_of_results)
+        expect(results.klass.name).to eq(Result.name)
+        expect(results.pluck('DISTINCT attachment_id')).not_to include(un_authored_attachment.id)
       end
     end
 
-    context 'filtered by keyword' do
-      subject { get :index, params: { q: keyword } }
-
-      let(:keyword) { 'e' }
-      let!(:nimble_result) { create :result, keyword: 'Nimble', attachment_id: attachment.id }
-      let!(:company_result) { create :result, keyword: 'company', attachment_id: attachment.id }
-      let!(:vietnam_result) { create :result, keyword: 'VietNam', attachment_id: attachment.id }
-
+    context 'when filtered by keyword' do
       it 'returns all filtered results of user' do
-        expect(subject).to have_http_status :success
-        expect(controller.instance_variable_get(:@results).size).to eq(2)
-        expect(controller.instance_variable_get(:@results).klass.name).to eq(Result.name)
-        expect(controller.instance_variable_get(:@results).pluck('DISTINCT keyword')).to include(nimble_result.keyword, vietnam_result.keyword)
-        expect(controller.instance_variable_get(:@results).pluck('DISTINCT keyword')).not_to include(company_result.keyword)
-        expect(controller.instance_variable_get(:@results).pluck('DISTINCT attachment_id')).not_to include(un_authored_attachment.id)
+        keyword = 'e'
+        attachment = create :attachment, user_id: user.id
+        nimble_result = create :result, keyword: 'Nimble', attachment_id: attachment.id
+        company_result = create :result, keyword: 'company', attachment_id: attachment.id
+        vietnam_result = create :result, keyword: 'VietNam', attachment_id: attachment.id
+        un_authored_attachment = create :attachment, user_id: other_user.id
+
+        get :index, params: { q: keyword }
+        results = controller.instance_variable_get(:@results)
+
+        expect(response).to have_http_status :success
+        expect(results.size).to eq(2)
+        expect(results.klass.name).to eq(Result.name)
+        expect(results.pluck('DISTINCT keyword')).to include(nimble_result.keyword, vietnam_result.keyword)
+        expect(results.pluck('DISTINCT keyword')).not_to include(company_result.keyword)
+        expect(results.pluck('DISTINCT attachment_id')).not_to include(un_authored_attachment.id)
       end
     end
   end
@@ -55,7 +58,10 @@ RSpec.describe ResultsController, type: :controller do
     let(:un_authored_result) { create :result, attachment_id: un_authored_attachment.id }
 
     it 'returns result of user' do
+      attachment = create :attachment, user_id: user.id
+      result = create :result, attachment_id: attachment.id
       params = { id: result.id }
+
       get :show, params: params
 
       expect(response).to have_http_status :success
@@ -64,7 +70,10 @@ RSpec.describe ResultsController, type: :controller do
     end
 
     it 'returns nil for un-authored result' do
+      un_authored_attachment = create :attachment, user_id: other_user.id
+      un_authored_result = create :result, attachment_id: un_authored_attachment.id
       params = { id: un_authored_result.id }
+
       get :show, params: params
 
       expect(response).to have_http_status :success

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -18,20 +18,19 @@ RSpec.describe ResultsController, type: :controller do
 
       it 'returns all results of the user' do
         user = create :user
-        another_user = create :user
         number_of_results = 10
         attachment = create :attachment, user_id: user.id
+        user_results = create_list :result, number_of_results, attachment_id: attachment.id
+
+        another_user = create :user
         another_user_attachment = create :attachment, user_id: another_user.id
-        create_list :result, number_of_results, attachment_id: attachment.id
+        create_list :result, number_of_results, attachment_id: another_user_attachment.id
 
         sign_in user
         get :index
         results = controller.instance_variable_get(:@results)
 
-        expect(response).to have_http_status :success
-        expect(results.size).to eq(number_of_results)
-        expect(results.klass.name).to eq(Result.name)
-        expect(results.pluck('DISTINCT attachment_id')).not_to include(another_user_attachment.id)
+        expect(results).to contain_exactly(*user_results)
       end
     end
 


### PR DESCRIPTION
Resolve #44 

## Why

Currently, we don't have tests for `results_controller`, as a developer, we need to improve the code coverage of the controller to 100%

## Acceptance Criteria

- Add unit tests for list results in case filtered by keyword or not
- Add unit tests for result detail

## Proof of Work

![Screen Shot 2022-10-13 at 16 41 13](https://user-images.githubusercontent.com/63148598/195562587-73165499-88a7-4307-b273-87e3c65f2608.png)
