### PR TITLE
[#46][Backend] Add test for results controller (external api)

### DIFF
--- a/spec/controller/api/v1/results_controller_spec.rb
+++ b/spec/controller/api/v1/results_controller_spec.rb
@@ -129,9 +129,8 @@ RSpec.describe Api::V1::ResultsController, type: :controller do
 
         sign_in attachment.user
         get :keywords
-        result = JSON.parse(response.body)
 
-        expect(result).to contain_exactly(nimble_result.keyword, vietnam_result.keyword)
+        expect(json_response).to contain_exactly(nimble_result.keyword, vietnam_result.keyword)
       end
 
       it 'returns unique keywords in all attachments' do
@@ -146,9 +145,8 @@ RSpec.describe Api::V1::ResultsController, type: :controller do
 
         sign_in user
         get :keywords
-        result = JSON.parse(response.body)
 
-        expect(result).to contain_exactly(nimble_result.keyword, company_result.keyword, another_vietnam_result.keyword)
+        expect(json_response).to contain_exactly(nimble_result.keyword, company_result.keyword, another_vietnam_result.keyword)
       end
     end
 

--- a/spec/controller/api/v1/results_controller_spec.rb
+++ b/spec/controller/api/v1/results_controller_spec.rb
@@ -7,118 +7,170 @@ RSpec.describe Api::V1::ResultsController, type: :controller do
 
   describe 'GET #index' do
     context 'without params' do
-      it 'returns all results of user' do
+      it 'returns success status' do
         user = create :user
-        number_of_results = 10
-        attachment = create :attachment, user_id: user.id
-        create_list :result, number_of_results, attachment_id: attachment.id
-        returned_result = user.results.to_json
 
         sign_in user
         get :index
 
         expect(response).to have_http_status :success
-        expect(response.body).to eq(returned_result)
+      end
+
+      it 'returns all results of user' do
+        number_of_results = 10
+        attachment = create :attachment
+        results = create_list :result, number_of_results, attachment: attachment
+
+        sign_in attachment.user
+        get :index
+
+        expect(response.body).to eq(results.to_json)
       end
     end
 
     context 'when filtered by keyword' do
-      it 'returns all filtered results of user' do
+      it 'returns success status' do
         keyword = 'e'
         user = create :user
-        attachment = create :attachment, user_id: user.id
-        nimble_result = create :result, keyword: 'Nimble', attachment_id: attachment.id
-        vietnam_result = create :result, keyword: 'VietNam', attachment_id: attachment.id
-        _company_result = create :result, keyword: 'company', attachment_id: attachment.id
-        returned_result = [nimble_result, vietnam_result].to_json
 
         sign_in user
         get :index, params: { q: keyword }
 
         expect(response).to have_http_status :success
-        expect(response.body).to eq(returned_result)
+      end
+
+      it 'returns all filtered results of user' do
+        keyword = 'e'
+        attachment = create :attachment
+        nimble_result = create :result, keyword: 'Nimble', attachment: attachment
+        vietnam_result = create :result, keyword: 'VietNam', attachment: attachment
+        _company_result = create :result, keyword: 'company', attachment: attachment
+        expected_result = [nimble_result, vietnam_result].to_json
+
+        sign_in attachment.user
+        get :index, params: { q: keyword }
+
+        expect(response.body).to eq(expected_result)
       end
     end
   end
 
   describe 'GET #show' do
-    it 'returns result of user' do
-      user = create :user
-      attachment = create :attachment, user_id: user.id
-      result = create :result, attachment_id: attachment.id
-      params = { id: result.id }
-      returned_result = result.to_json
+    context 'given the user has the permission' do
+      it 'returns success status' do
+        attachment = create :attachment
+        result = create :result, attachment: attachment
 
-      sign_in user
-      get :show, params: params
+        sign_in attachment.user
+        get :index, params: { id: result.id }
 
-      expect(response).to have_http_status :success
-      expect(response.body).to eq(returned_result)
+        expect(response).to have_http_status :success
+      end
+
+      it 'returns the result' do
+        attachment = create :attachment
+        result = create :result, attachment: attachment
+        expected_result = result.to_json
+
+        sign_in attachment.user
+        get :show, params: { id: result.id }
+
+        expect(response).to have_http_status :success
+        expect(response.body).to eq(expected_result)
+      end
     end
 
-    it 'returns nil for un-authored result' do
-      user = create :user
-      other_user = create :user
-      un_authored_attachment = create :attachment, user_id: other_user.id
-      un_authored_result = create :result, attachment_id: un_authored_attachment.id
-      params = { id: un_authored_result.id }
-      returned_result = nil.to_json
+    context 'given the user does NOT have the permission' do
+      it 'returns success status' do
+        user = create :user
+        another_user = create :user
+        another_user_attachment = create :attachment, user: another_user
+        another_user_result = create :result, attachment: another_user_attachment
 
-      sign_in user
-      get :show, params: params
+        sign_in user
+        get :show, params: { id: another_user_result.id }
 
-      expect(response).to have_http_status :success
-      expect(response.body).to eq(returned_result)
+        expect(response).to have_http_status :success
+      end
+
+      it 'returns nil for un-authored result' do
+        user = create :user
+        another_user = create :user
+        another_user_attachment = create :attachment, user: another_user
+        another_user_result = create :result, attachment: another_user_attachment
+
+        sign_in user
+        get :show, params: { id: another_user_result.id }
+
+        expect(response.body).to eq(nil.to_json)
+      end
     end
   end
 
   describe 'GET #keywords' do
-    it 'returns unique keywords' do
-      user = create :user
-      attachment = create :attachment, user_id: user.id
+    context 'given the user has many results' do
+      it 'returns success status' do
+        attachment = create :attachment
+        create :result, keyword: 'Nimble', attachment: attachment
+        create :result, keyword: 'VietNam', attachment: attachment
 
-      nimble_result = create :result, keyword: 'Nimble', attachment_id: attachment.id
-      _second_nimble_result = create :result, keyword: 'Nimble', attachment_id: attachment.id
-      vietnam_result = create :result, keyword: 'VietNam', attachment_id: attachment.id
-      _second_vietnam_result = create :result, keyword: 'VietNam', attachment_id: attachment.id
+        sign_in attachment.user
+        get :keywords
 
-      sign_in user
-      get :keywords
-      result = JSON.parse(response.body)
+        expect(response).to have_http_status :success
+      end
 
-      expect(response).to have_http_status :success
-      expect(result.size).to eq(2)
-      expect(result).to include(nimble_result.keyword, vietnam_result.keyword)
+      it 'returns unique keywords in one attachment' do
+        attachment = create :attachment
+
+        nimble_result = create :result, keyword: 'Nimble', attachment: attachment
+        vietnam_result = create :result, keyword: 'VietNam', attachment: attachment
+        _second_nimble_result = create :result, keyword: 'Nimble', attachment: attachment
+        _second_vietnam_result = create :result, keyword: 'VietNam', attachment: attachment
+
+        sign_in attachment.user
+        get :keywords
+        result = JSON.parse(response.body)
+
+        expect(result).to contain_exactly(nimble_result.keyword, vietnam_result.keyword)
+      end
+
+      it 'returns unique keywords in all attachments' do
+        user = create :user
+        attachment = create :attachment, user_id: user.id
+        another_attachment = create :attachment, user_id: user.id
+
+        nimble_result = create :result, keyword: 'Nimble', attachment_id: attachment.id
+        company_result = create :result, keyword: 'company', attachment_id: attachment.id
+        another_vietnam_result = create :result, keyword: 'VietNam', attachment_id: another_attachment.id
+        _another_nimble_result = create :result, keyword: 'Nimble', attachment_id: another_attachment.id
+
+        sign_in user
+        get :keywords
+        result = JSON.parse(response.body)
+
+        expect(result).to contain_exactly(nimble_result.keyword, company_result.keyword, another_vietnam_result.keyword)
+      end
     end
 
-    it 'returns unique keywords in all attachments' do
-      user = create :user
-      attachment = create :attachment, user_id: user.id
-      other_attachment = create :attachment, user_id: user.id
+    context 'given the user does NOT have any results' do
+      it 'returns success status' do
+        user = create :user
 
-      nimble_result = create :result, keyword: 'Nimble', attachment_id: attachment.id
-      company_result = create :result, keyword: 'company', attachment_id: attachment.id
-      _other_nimble_result = create :result, keyword: 'Nimble', attachment_id: other_attachment.id
-      other_vietnam_result = create :result, keyword: 'VietNam', attachment_id: other_attachment.id
+        sign_in user
+        get :keywords
 
-      sign_in user
-      get :keywords
-      result = JSON.parse(response.body)
+        expect(response).to have_http_status :success
+      end
 
-      expect(response).to have_http_status :success
-      expect(result.size).to eq(3)
-      expect(result).to include(nimble_result.keyword, company_result.keyword, other_vietnam_result.keyword)
-    end
+      it 'returns an empty array' do
+        user = create :user
 
-    it 'does NOT have any keywords' do
-      user = create :user
+        sign_in user
+        get :keywords
 
-      sign_in user
-      get :keywords
-      returned_result = [].to_json
-
-      expect(response).to have_http_status :success
-      expect(response.body).to eq(returned_result)
+        expect(response.body).to eq([].to_json)
+      end
     end
   end
 end

--- a/spec/controller/api/v1/results_controller_spec.rb
+++ b/spec/controller/api/v1/results_controller_spec.rb
@@ -1,0 +1,124 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::ResultsController, type: :controller do
+  describe 'Filters' do
+    it { is_expected.to use_before_action(:authenticate_user!) }
+  end
+
+  describe 'GET #index' do
+    context 'without params' do
+      it 'returns all results of user' do
+        user = create :user
+        number_of_results = 10
+        attachment = create :attachment, user_id: user.id
+        create_list :result, number_of_results, attachment_id: attachment.id
+        returned_result = user.results.to_json
+
+        sign_in user
+        get :index
+
+        expect(response).to have_http_status :success
+        expect(response.body).to eq(returned_result)
+      end
+    end
+
+    context 'when filtered by keyword' do
+      it 'returns all filtered results of user' do
+        keyword = 'e'
+        user = create :user
+        attachment = create :attachment, user_id: user.id
+        nimble_result = create :result, keyword: 'Nimble', attachment_id: attachment.id
+        vietnam_result = create :result, keyword: 'VietNam', attachment_id: attachment.id
+        _company_result = create :result, keyword: 'company', attachment_id: attachment.id
+        returned_result = [nimble_result, vietnam_result].to_json
+
+        sign_in user
+        get :index, params: { q: keyword }
+
+        expect(response).to have_http_status :success
+        expect(response.body).to eq(returned_result)
+      end
+    end
+  end
+
+  describe 'GET #show' do
+    it 'returns result of user' do
+      user = create :user
+      attachment = create :attachment, user_id: user.id
+      result = create :result, attachment_id: attachment.id
+      params = { id: result.id }
+      returned_result = result.to_json
+
+      sign_in user
+      get :show, params: params
+
+      expect(response).to have_http_status :success
+      expect(response.body).to eq(returned_result)
+    end
+
+    it 'returns nil for un-authored result' do
+      user = create :user
+      other_user = create :user
+      un_authored_attachment = create :attachment, user_id: other_user.id
+      un_authored_result = create :result, attachment_id: un_authored_attachment.id
+      params = { id: un_authored_result.id }
+      returned_result = nil.to_json
+
+      sign_in user
+      get :show, params: params
+
+      expect(response).to have_http_status :success
+      expect(response.body).to eq(returned_result)
+    end
+  end
+
+  describe 'GET #keywords' do
+    it 'returns unique keywords' do
+      user = create :user
+      attachment = create :attachment, user_id: user.id
+
+      nimble_result = create :result, keyword: 'Nimble', attachment_id: attachment.id
+      _second_nimble_result = create :result, keyword: 'Nimble', attachment_id: attachment.id
+      vietnam_result = create :result, keyword: 'VietNam', attachment_id: attachment.id
+      _second_vietnam_result = create :result, keyword: 'VietNam', attachment_id: attachment.id
+
+      sign_in user
+      get :keywords
+      result = JSON.parse(response.body)
+
+      expect(response).to have_http_status :success
+      expect(result.size).to eq(2)
+      expect(result).to include(nimble_result.keyword, vietnam_result.keyword)
+    end
+
+    it 'returns unique keywords in all attachments' do
+      user = create :user
+      attachment = create :attachment, user_id: user.id
+      other_attachment = create :attachment, user_id: user.id
+
+      nimble_result = create :result, keyword: 'Nimble', attachment_id: attachment.id
+      company_result = create :result, keyword: 'company', attachment_id: attachment.id
+      _other_nimble_result = create :result, keyword: 'Nimble', attachment_id: other_attachment.id
+      other_vietnam_result = create :result, keyword: 'VietNam', attachment_id: other_attachment.id
+
+      sign_in user
+      get :keywords
+      result = JSON.parse(response.body)
+
+      expect(response).to have_http_status :success
+      expect(result.size).to eq(3)
+      expect(result).to include(nimble_result.keyword, company_result.keyword, other_vietnam_result.keyword)
+    end
+
+    it 'do NOT have any keywords' do
+      user = create :user
+
+      sign_in user
+      get :keywords
+      returned_result = [].to_json
+
+      expect(response).to have_http_status :success
+      expect(response.body).to eq(returned_result)
+    end
+  end
+end

--- a/spec/controller/api/v1/results_controller_spec.rb
+++ b/spec/controller/api/v1/results_controller_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Api::V1::ResultsController, type: :controller do
       expect(result).to include(nimble_result.keyword, company_result.keyword, other_vietnam_result.keyword)
     end
 
-    it 'do NOT have any keywords' do
+    it 'does NOT have any keywords' do
       user = create :user
 
       sign_in user

--- a/spec/controller/api/v1/results_controller_spec.rb
+++ b/spec/controller/api/v1/results_controller_spec.rb
@@ -75,7 +75,6 @@ RSpec.describe Api::V1::ResultsController, type: :controller do
         sign_in attachment.user
         get :show, params: { id: result.id }
 
-        expect(response).to have_http_status :success
         expect(response.body).to eq(expected_result)
       end
     end


### PR DESCRIPTION
Resolve #46 

## Why

Currently, we don't have tests for external `results_controller`, as a developer, we need to improve the code coverage of the controller to 100%

## Acceptance Criteria

- Add unit tests for list results in case filtered by keyword or not
- Add unit tests for result detail
- Add unit tests to get keywords of user

## Proof of Work

![Screen Shot 2022-10-14 at 11 03 40](https://user-images.githubusercontent.com/63148598/195759883-3be4d6fc-878f-4182-80c1-0c3b2b9d19d0.png)