### PR TITLE
[#45][Backend] Add test for attachments controller (external api)

### DIFF
--- a/spec/controllers/api/v1/attachments_controller_spec.rb
+++ b/spec/controllers/api/v1/attachments_controller_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Api::V1::AttachmentsController, type: :controller do
   end
 
   describe 'POST #create' do
-    context 'when upload valid file' do
-      it 'creates a new attachment and redirects to the detail page' do
+    context 'when a valid file is uploaded' do
+      it 'creates a new attachment' do
         user = create :user
         params = {
           file: fixture_file_upload('valid_file.csv', 'text/csv')
@@ -21,7 +21,7 @@ RSpec.describe Api::V1::AttachmentsController, type: :controller do
       end
     end
 
-    context 'when upload invalid file' do
+    context 'when an invalid file is uploaded' do
       it 'returns an error message' do
         user = create :user
         error_message = 'Cannot handle empty file!'
@@ -31,25 +31,23 @@ RSpec.describe Api::V1::AttachmentsController, type: :controller do
 
         sign_in user
         post :create, params: params
-        result = JSON.parse(response.body)
 
-        expect(result['error']).to be_present
-        expect(result['error']).to eq(error_message)
+        expect(json_response[:error]).to be_present
+        expect(json_response[:error]).to eq(error_message)
       end
     end
 
     context 'when receive a StandardError from service' do
       it 'returns an error message' do
         user = create :user
-        error_message = "Error message test"
-        sign_in user
+        error_message = 'Error message from service'
         allow_any_instance_of(Attachments::CreateService).to receive(:call).and_raise(StandardError, error_message)
 
+        sign_in user
         post :create
-        result = JSON.parse(response.body)
 
-        expect(result['error']).to be_present
-        expect(result['error']).to eq(error_message)
+        expect(json_response[:error]).to be_present
+        expect(json_response[:error]).to eq(error_message)
       end
     end
   end

--- a/spec/controllers/api/v1/attachments_controller_spec.rb
+++ b/spec/controllers/api/v1/attachments_controller_spec.rb
@@ -37,5 +37,20 @@ RSpec.describe Api::V1::AttachmentsController, type: :controller do
         expect(result['error']).to eq(error_message)
       end
     end
+
+    context 'when receive a StandardError from service' do
+      it 'returns an error message' do
+        user = create :user
+        error_message = "Error message test"
+        sign_in user
+        allow_any_instance_of(Attachments::CreateService).to receive(:call).and_raise(StandardError, error_message)
+
+        post :create
+        result = JSON.parse(response.body)
+
+        expect(result['error']).to be_present
+        expect(result['error']).to eq(error_message)
+      end
+    end
   end
 end

--- a/spec/controllers/api/v1/attachments_controller_spec.rb
+++ b/spec/controllers/api/v1/attachments_controller_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::AttachmentsController, type: :controller do
+  describe 'Filters' do
+    it { should use_before_action(:authenticate_user!) }
+  end
+
+  describe 'POST #create' do
+    context 'when upload valid file' do
+      it 'creates a new attachment and redirects to the detail page' do
+        user = create :user
+        params = {
+          file: fixture_file_upload('valid_file.csv', 'text/csv')
+        }
+
+        sign_in user
+        post :create, params: params
+
+        expect(user.attachments.size).to eq(1)
+        expect(response.body).to eq(user.attachments.last.to_json)
+      end
+    end
+
+    context 'when upload invalid file' do
+      it 'returns an error message' do
+        user = create :user
+        error_message = 'Cannot handle empty file!'
+        params = {
+          file: fixture_file_upload('empty_file.csv', 'text/csv')
+        }
+
+        sign_in user
+        post :create, params: params
+        result = JSON.parse(response.body)
+
+        expect(result['error']).to be_present
+        expect(result['error']).to eq(error_message)
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v1/attachments_controller_spec.rb
+++ b/spec/controllers/api/v1/attachments_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Api::V1::AttachmentsController, type: :controller do
       end
     end
 
-    context 'when receive a StandardError from service' do
+    context 'when receiving a StandardError from the Attachments::CreateService' do
       it 'returns an error message' do
         user = create :user
         error_message = 'Error message from service'

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Request
+  module JsonHelpers
+    def json_response
+      @json_response ||= JSON.parse(response.body, symbolize_names: true)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include RSpec::Rails::ControllerExampleGroup, type: :controller # required to have access to routes block
+  config.include Request::JsonHelpers, type: :controller
+end


### PR DESCRIPTION
Resolve #45 

## What happened

We don't have any test cases for the attachments controller.

## Insight

Write test cases to create an attachment and also scrape data from google, in the worst case, the error happens, it returns an error message to the user.

## Proof of Work

![Screen Shot 2022-10-14 at 14 05 38](https://user-images.githubusercontent.com/63148598/195783881-caff855a-4b94-485e-a1a3-85da1d4ce3ef.png)
